### PR TITLE
ci(release): automate crates.io publishing

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,18 @@
+# Publishing a release
+
+The `Publish crates.io release` workflow publishes every workspace crate in
+dependency order. It skips crate versions that already exist, so a failed run
+can be restarted safely.
+
+Before publishing:
+
+1. Give every workspace package the same new version and update `Cargo.lock`.
+2. Ensure CI passes on `main`.
+3. Create a GitHub environment named `crates-io`.
+4. Add a `CARGO_REGISTRY_TOKEN` secret to that environment. Use a crates.io API
+   token authorized to publish all `bevy-aqua-*` crates.
+5. Publish a GitHub release tagged `v<workspace-version>`.
+
+The workflow can also be started manually. Enter the exact workspace version
+when prompted. Protect the `crates-io` environment with required reviewers to
+prevent accidental publication.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
-      - run: cargo test --workspace --lib --locked
+      - run: cargo test --workspace --lib
 
   wasm:
     name: Check browser WebGPU example
@@ -34,4 +34,4 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --locked --target wasm32-unknown-unknown --example browser_ocean
+      - run: cargo check --target wasm32-unknown-unknown --example browser_ocean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  native:
+    name: Format and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo test --workspace --lib --locked
+
+  wasm:
+    name: Check browser WebGPU example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --locked --target wasm32-unknown-unknown --example browser_ocean

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,110 @@
+name: Publish crates.io release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact workspace version to publish, without a v prefix
+        required: true
+        type: string
+
+concurrency:
+  group: crates-io-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish workspace
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Validate release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          mapfile -t versions < <(
+            cargo metadata --locked --no-deps --format-version 1 |
+              jq -r '.packages[].version' | sort -u
+          )
+          if (( ${#versions[@]} != 1 )); then
+            printf 'Workspace packages do not share one version: %s\n' "${versions[*]}" >&2
+            exit 1
+          fi
+
+          version="${versions[0]}"
+          if [[ "${{ github.event_name }}" == release ]]; then
+            requested="${RELEASE_TAG#v}"
+          else
+            requested="$REQUESTED_VERSION"
+          fi
+          if [[ "$requested" != "$version" ]]; then
+            echo "Requested version $requested does not match workspace version $version" >&2
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Test publishable workspace
+        run: |
+          cargo fmt --all -- --check
+          cargo test --workspace --lib --locked
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [[ -z "$CARGO_REGISTRY_TOKEN" ]]; then
+            echo 'The crates-io environment needs a CARGO_REGISTRY_TOKEN secret.' >&2
+            exit 1
+          fi
+
+          crates=(
+            bevy-aqua-fft
+            bevy-aqua-sdf
+            bevy-aqua-geom
+            bevy-aqua-light
+            bevy-aqua-optics
+            bevy-aqua-core
+            bevy-aqua-waves
+            bevy-aqua-foam
+            bevy-aqua-shore
+            bevy-aqua-query
+            bevy-aqua-reflect
+            bevy-aqua-spray
+            bevy-aqua-motion
+            bevy-aqua
+          )
+
+          for crate in "${crates[@]}"; do
+            endpoint="https://crates.io/api/v1/crates/$crate/$VERSION"
+            if curl --fail --silent --show-error "$endpoint" >/dev/null; then
+              echo "$crate $VERSION is already published; skipping"
+              continue
+            fi
+
+            cargo publish --locked --package "$crate"
+
+            # A dependent package cannot publish until crates.io exposes this
+            # version through its API and sparse index.
+            available=false
+            for _ in {1..30}; do
+              if curl --fail --silent "$endpoint" >/dev/null; then
+                available=true
+                break
+              fi
+              sleep 10
+            done
+            if [[ "$available" != true ]]; then
+              echo "$crate $VERSION did not become available within five minutes" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           mapfile -t versions < <(
-            cargo metadata --locked --no-deps --format-version 1 |
+            cargo metadata --no-deps --format-version 1 |
               jq -r '.packages[].version' | sort -u
           )
           if (( ${#versions[@]} != 1 )); then
@@ -56,7 +56,7 @@ jobs:
       - name: Test publishable workspace
         run: |
           cargo fmt --all -- --check
-          cargo test --workspace --lib --locked
+          cargo test --workspace --lib
 
       - name: Publish crates in dependency order
         env:
@@ -91,7 +91,7 @@ jobs:
               continue
             fi
 
-            cargo publish --locked --package "$crate"
+            cargo publish --package "$crate"
 
             # A dependent package cannot publish until crates.io exposes this
             # version through its API and sparse index.


### PR DESCRIPTION
## Summary

- add native formatting and workspace library tests on pushes and pull requests
- check the WebGPU browser example for `wasm32-unknown-unknown`
- publish all 14 crates in dependency order on a GitHub release or confirmed manual run
- skip versions already present on crates.io so interrupted runs are restartable
- document the protected `crates-io` environment and token setup

## Safety

The publish job requires an exact workspace-version match and a `CARGO_REGISTRY_TOKEN` secret in the protected `crates-io` environment. Ordinary pushes and pull requests cannot publish.

## Validation

- `actionlint` 1.7.12
- workflow YAML parsing
- current workspace package graph checked against the explicit publish order
