### PR TITLE
chore(release): prepare 0.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo test --workspace --lib
       - run: cargo check --examples
-      - run: cargo package --no-verify
+      - run: cargo package --workspace --no-verify
 
   wasm:
     name: Check browser WebGPU examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.1.3] - 2026-08-30
+
+### Added
+
+- Browser WebGPU/Wasm support across the Aqua render stack, contributed by
+  [@wellscrosby](https://github.com/wellscrosby) in
+  [#1](https://github.com/sayhisam1/bevy-aqua/pull/1).
+- Nine focused, procedural examples that run unchanged on native and Wasm,
+  with expected-look screenshots and a hosted WebGPU gallery.
+- GitHub Actions workflows for native/Wasm CI, GitHub Pages deployment, and
+  ordered crates.io publication of the full workspace.
+
+### Changed
+
+- Replace the configurable showcase and browser-only demo with small examples
+  for oceans, spectral waves, foam, bounded water, rivers, terrain beds, water
+  optics, planar reflections, and GPU wave queries.
+- Centralize packed field-texture layout contracts and strengthen render-pass
+  shader variant validation.
+
+### Fixed
+
+- Use a WebGPU-filterable foam storage format and Web-compatible diagnostic
+  timestamps.
+- Preserve authored mip filtering with derivative-free explicit shader LOD.
+
 ## [0.1.2] - 2026-08-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,26 +3,26 @@ members = ["crates/bevy-aqua-fft", "crates/bevy-aqua-sdf", "crates/bevy-aqua-geo
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sayhisam1/bevy-aqua"
 
 [workspace.dependencies]
-bevy-aqua-core = { path = "crates/bevy-aqua-core", version = "0.1.2" }
-bevy-aqua-fft = { path = "crates/bevy-aqua-fft", version = "0.1.2" }
-bevy-aqua-foam = { path = "crates/bevy-aqua-foam", version = "0.1.2" }
-bevy-aqua-geom = { path = "crates/bevy-aqua-geom", version = "0.1.2" }
-bevy-aqua-light = { path = "crates/bevy-aqua-light", version = "0.1.2" }
-bevy-aqua-optics = { path = "crates/bevy-aqua-optics", version = "0.1.2" }
-bevy-aqua-motion = { path = "crates/bevy-aqua-motion", version = "0.1.2" }
-bevy-aqua-query = { path = "crates/bevy-aqua-query", version = "0.1.2" }
-bevy-aqua-reflect = { path = "crates/bevy-aqua-reflect", version = "0.1.2" }
-bevy-aqua-sdf = { path = "crates/bevy-aqua-sdf", version = "0.1.2" }
-bevy-aqua-spray = { path = "crates/bevy-aqua-spray", version = "0.1.2" }
-bevy-aqua-shore = { path = "crates/bevy-aqua-shore", version = "0.1.2" }
-bevy-aqua-waves = { path = "crates/bevy-aqua-waves", version = "0.1.2" }
+bevy-aqua-core = { path = "crates/bevy-aqua-core", version = "0.1.3" }
+bevy-aqua-fft = { path = "crates/bevy-aqua-fft", version = "0.1.3" }
+bevy-aqua-foam = { path = "crates/bevy-aqua-foam", version = "0.1.3" }
+bevy-aqua-geom = { path = "crates/bevy-aqua-geom", version = "0.1.3" }
+bevy-aqua-light = { path = "crates/bevy-aqua-light", version = "0.1.3" }
+bevy-aqua-optics = { path = "crates/bevy-aqua-optics", version = "0.1.3" }
+bevy-aqua-motion = { path = "crates/bevy-aqua-motion", version = "0.1.3" }
+bevy-aqua-query = { path = "crates/bevy-aqua-query", version = "0.1.3" }
+bevy-aqua-reflect = { path = "crates/bevy-aqua-reflect", version = "0.1.3" }
+bevy-aqua-sdf = { path = "crates/bevy-aqua-sdf", version = "0.1.3" }
+bevy-aqua-spray = { path = "crates/bevy-aqua-spray", version = "0.1.3" }
+bevy-aqua-shore = { path = "crates/bevy-aqua-shore", version = "0.1.3" }
+bevy-aqua-waves = { path = "crates/bevy-aqua-waves", version = "0.1.3" }
 bevy = { version = "0.19", default-features = false }
 bevy_ecs = "0.19"
 bevy_hanabi = { version = "0.19.0", default-features = false, features = ["3d"] }


### PR DESCRIPTION
## Summary

- bump all 14 workspace crates from 0.1.2 to 0.1.3
- update every internal crates.io dependency requirement to 0.1.3
- document WebGPU/Wasm, focused examples, release automation, and shader fixes in the changelog

## Validation

- all 14 packages report exactly version 0.1.3
- all 14 version endpoints are currently absent on crates.io
- `cargo fmt --all -- --check`
- `cargo test --workspace --lib`
- `cargo check --target wasm32-unknown-unknown --examples`
- `cargo package --workspace --no-verify` (all 14 packages)
- `actionlint` 1.7.12

After merge, publishing GitHub release `v0.1.3` will trigger the protected crates.io workflow.
